### PR TITLE
Refresh dashboard UI with Tailwind design

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -391,151 +391,208 @@ if ($salesPreview || $stockPreview) {
     $activeSection = 'parameters';
 }
 
-?><!DOCTYPE html>
+?>
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Multi-Warehouse Demand Planning</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
-    <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css">
-    <link rel="stylesheet" href="styles.css">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Demand Planning Dashboard</title>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <script>
+        tailwind.config = {
+            darkMode: 'class',
+            theme: {
+                extend: {
+                    colors: {
+                        primary: '#007BFF',
+                        'background-light': '#F8F9FA',
+                        'background-dark': '#18181B',
+                        'card-light': '#FFFFFF',
+                        'card-dark': '#27272A',
+                        'text-light': '#1F2937',
+                        'text-dark': '#F4F4F5',
+                        'subtext-light': '#6B7280',
+                        'subtext-dark': '#A1A1AA',
+                        'border-light': '#E5E7EB',
+                        'border-dark': '#3F3F46'
+                    },
+                    fontFamily: {
+                        display: ['Inter', 'sans-serif']
+                    },
+                    borderRadius: {
+                        DEFAULT: '0.5rem'
+                    }
+                }
+            }
+        };
+    </script>
+    <style>
+        body {
+            font-family: 'Inter', sans-serif;
+        }
+    </style>
 </head>
-<body>
-<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-    <div class="container-fluid">
-        <span class="navbar-brand">Demand Planning Dashboard</span>
-        <?php if (is_logged_in()): ?>
-        <div class="d-flex">
-            <a class="btn btn-outline-light btn-sm" href="?action=logout">Logout</a>
+<body class="bg-background-light dark:bg-background-dark text-text-light dark:text-text-dark">
+<div class="flex flex-col min-h-screen">
+    <header class="bg-card-light dark:bg-card-dark shadow-sm border-b border-border-light dark:border-border-dark">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex justify-between items-center h-16">
+                <div class="flex items-center space-x-4">
+                    <span class="material-icons text-primary" style="font-size: 28px;">analytics</span>
+                    <h1 class="text-xl font-bold">Demand Planning Dashboard</h1>
+                </div>
+                <div class="flex items-center space-x-4">
+                    <button type="button" class="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700">
+                        <span class="material-icons text-subtext-light dark:text-subtext-dark">notifications</span>
+                    </button>
+                    <div class="relative">
+                        <img src="https://lh3.googleusercontent.com/aida-public/AB6AXuA1EHhdTmdIUXzI6p094ec-Hebua5dTvkHsKRbw_19As05IrBSX88cMCM25ccIq5Emug1XArfd7dr6BYMnETiJPff2-Cp8auQ4i2F-nXIfgnIFfhYVJGhpbpPo47c_nPMK-KeSDtrCppYqxzacY9SylKYIadsqfSOHSwWY81lZQ7SzRWYdIL-h7hjQ8PgFpoizqcbpeEWsQNiCxgcaObVde2ZKuHNZqo25HLldjtWvdYrLRhebEmmMwoVXMMJPTaNv_G_r9El3Bjh8" alt="User avatar" class="h-9 w-9 rounded-full object-cover">
+                        <span class="absolute right-0 bottom-0 block h-2.5 w-2.5 rounded-full bg-green-400 ring-2 ring-white dark:ring-card-dark"></span>
+                    </div>
+                    <?php if (is_logged_in()): ?>
+                    <a href="?action=logout" class="ml-2 px-4 py-2 text-sm font-medium text-primary bg-primary/10 dark:bg-primary/20 rounded-md hover:bg-primary/20 dark:hover:bg-primary/30 transition">Logout</a>
+                    <?php endif; ?>
+                </div>
+            </div>
         </div>
-        <?php endif; ?>
-    </div>
-</nav>
-<div class="container-fluid my-4 px-4">
-    <?php foreach ($messages as $message): ?>
-        <div class="alert alert-success alert-dismissible fade show" role="alert">
-            <?= htmlspecialchars($message, ENT_QUOTES) ?>
-            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-        </div>
-    <?php endforeach; ?>
-    <?php foreach ($errors as $error): ?>
-        <div class="alert alert-danger alert-dismissible fade show" role="alert">
-            <?= htmlspecialchars($error, ENT_QUOTES) ?>
-            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-        </div>
-    <?php endforeach; ?>
+    </header>
+    <main class="flex-grow p-4 sm:p-6 lg:px-8 lg:p-8">
+        <div class="max-w-7xl mx-auto space-y-6">
+            <?php foreach ($messages as $message): ?>
+                <div class="rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-green-800 dark:border-green-900 dark:bg-green-900/20 dark:text-green-200">
+                    <?= htmlspecialchars($message, ENT_QUOTES) ?>
+                </div>
+            <?php endforeach; ?>
+            <?php foreach ($errors as $error): ?>
+                <div class="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-red-700 dark:border-red-900 dark:bg-red-900/20 dark:text-red-200">
+                    <?= htmlspecialchars($error, ENT_QUOTES) ?>
+                </div>
+            <?php endforeach; ?>
 
-    <?php if (!is_logged_in()): ?>
-        <div class="row justify-content-center">
-            <div class="col-md-6 col-lg-4">
-                <div class="card shadow-sm">
-                    <div class="card-body">
-                        <h5 class="card-title text-center mb-4">Admin Login</h5>
-                        <form method="post" novalidate>
+            <?php if (!is_logged_in()): ?>
+                <div class="flex justify-center py-10">
+                    <div class="w-full max-w-md bg-card-light dark:bg-card-dark border border-border-light dark:border-border-dark rounded-lg shadow-sm p-6">
+                        <h2 class="text-xl font-semibold text-center mb-6">Admin Login</h2>
+                        <form method="post" class="space-y-4" novalidate>
                             <input type="hidden" name="action" value="login">
-                            <div class="mb-3">
-                                <label class="form-label" for="username">Username</label>
-                                <input class="form-control" type="text" id="username" name="username" required autofocus>
+                            <div>
+                                <label for="username" class="block text-sm font-medium text-subtext-light dark:text-subtext-dark mb-1">Username</label>
+                                <input type="text" id="username" name="username" required autofocus class="w-full rounded-md border border-border-light dark:border-border-dark bg-background-light dark:bg-background-dark px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary">
                             </div>
-                            <div class="mb-3">
-                                <label class="form-label" for="password">Password</label>
-                                <input class="form-control" type="password" id="password" name="password" required>
+                            <div>
+                                <label for="password" class="block text-sm font-medium text-subtext-light dark:text-subtext-dark mb-1">Password</label>
+                                <input type="password" id="password" name="password" required class="w-full rounded-md border border-border-light dark:border-border-dark bg-background-light dark:bg-background-dark px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary">
                             </div>
-                            <button class="btn btn-primary w-100" type="submit">Sign in</button>
+                            <button type="submit" class="w-full inline-flex justify-center rounded-md bg-primary px-4 py-2 text-white font-semibold shadow-sm hover:bg-primary/90 transition">Login</button>
                         </form>
                     </div>
                 </div>
-            </div>
-        </div>
-    <?php else: ?>
-        <ul class="nav nav-pills mb-4" id="dashboardTabs" role="tablist">
-            <li class="nav-item" role="presentation">
-                <button class="nav-link<?= $activeSection === 'dashboard' ? ' active' : '' ?>" data-section="dashboard" type="button">Dashboard</button>
-            </li>
-            <li class="nav-item" role="presentation">
-                <button class="nav-link<?= $activeSection === 'imports' ? ' active' : '' ?>" data-section="imports" type="button">Data Import</button>
-            </li>
-            <li class="nav-item" role="presentation">
-                <button class="nav-link<?= $activeSection === 'warehouses' ? ' active' : '' ?>" data-section="warehouses" type="button">Warehouses</button>
-            </li>
-            <li class="nav-item" role="presentation">
-                <button class="nav-link<?= $activeSection === 'parameters' ? ' active' : '' ?>" data-section="parameters" type="button">Parameters</button>
-            </li>
-        </ul>
+            <?php else: ?>
+                <?php
+                    $navButton = function (string $section, string $label) use ($activeSection): string {
+                        $base = 'px-4 py-2 text-sm font-medium rounded-md flex-1 text-center transition';
+                        if ($section === $activeSection) {
+                            return $base . ' bg-primary text-white shadow';
+                        }
+                        return $base . ' text-subtext-light dark:text-subtext-dark hover:bg-gray-100 dark:hover:bg-gray-700';
+                    };
+                ?>
+                <nav class="bg-card-light dark:bg-card-dark border border-border-light dark:border-border-dark rounded-lg p-2">
+                    <div class="flex flex-col sm:flex-row gap-2" id="dashboardTabs">
+                        <button type="button" data-section="dashboard" class="<?= $navButton('dashboard', 'Dashboard') ?>">Dashboard</button>
+                        <button type="button" data-section="imports" class="<?= $navButton('imports', 'Data Import') ?>">Data Import</button>
+                        <button type="button" data-section="warehouses" class="<?= $navButton('warehouses', 'Warehouses') ?>">Warehouses</button>
+                        <button type="button" data-section="parameters" class="<?= $navButton('parameters', 'Parameters') ?>">Parameters</button>
+                    </div>
+                </nav>
 
-        <section id="section-dashboard"<?= $activeSection === 'dashboard' ? '' : ' class="d-none"' ?>>
-            <div class="row g-4 mb-4">
-                <div class="col-12">
-                    <div class="card shadow-sm h-100">
-                        <div class="card-header d-flex flex-wrap align-items-center justify-content-between">
-                            <h5 class="mb-0">Demand &amp; Replenishment</h5>
-                            <div class="d-flex flex-wrap gap-2">
-                                <select class="form-select form-select-sm" id="warehouseFilter">
-                                    <option value="">All Warehouses</option>
-                                    <?php foreach ($warehouses as $warehouse): ?>
-                                        <option value="<?= (int) $warehouse['id'] ?>"><?= htmlspecialchars($warehouse['code'] . ' · ' . $warehouse['name'], ENT_QUOTES) ?></option>
-                                    <?php endforeach; ?>
-                                </select>
-                                <input type="text" class="form-control form-control-sm" id="skuFilter" placeholder="Filter by SKU">
+                <section id="section-dashboard" class="<?= $activeSection === 'dashboard' ? '' : 'hidden' ?> space-y-6">
+                    <div class="bg-card-light dark:bg-card-dark p-6 rounded-lg shadow-sm border border-border-light dark:border-border-dark">
+                        <div class="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 mb-6">
+                            <div>
+                                <h2 class="text-2xl font-semibold">Demand &amp; Replenishment</h2>
+                                <p class="text-sm text-subtext-light dark:text-subtext-dark">Track inventory across warehouses and calculate reorder quantities.</p>
+                            </div>
+                            <div class="flex flex-col sm:flex-row gap-3 w-full md:w-auto">
+                                <div class="relative w-full sm:w-56">
+                                    <span class="material-icons absolute left-3 top-1/2 -translate-y-1/2 text-subtext-light dark:text-subtext-dark">warehouse</span>
+                                    <select id="warehouseFilter" class="w-full pl-10 pr-4 py-2 rounded-md border border-border-light dark:border-border-dark bg-background-light dark:bg-background-dark focus:outline-none focus:ring-2 focus:ring-primary">
+                                        <option value="">All Warehouses</option>
+                                        <?php foreach ($warehouses as $warehouse): ?>
+                                            <option value="<?= (int) $warehouse['id'] ?>"><?= htmlspecialchars($warehouse['code'] . ' · ' . $warehouse['name'], ENT_QUOTES) ?></option>
+                                        <?php endforeach; ?>
+                                    </select>
+                                </div>
+                                <div class="relative w-full sm:w-56">
+                                    <span class="material-icons absolute left-3 top-1/2 -translate-y-1/2 text-subtext-light dark:text-subtext-dark">search</span>
+                                    <input type="search" id="skuFilter" placeholder="Filter by SKU" class="w-full pl-10 pr-4 py-2 rounded-md border border-border-light dark:border-border-dark bg-background-light dark:bg-background-dark focus:outline-none focus:ring-2 focus:ring-primary">
+                                </div>
                             </div>
                         </div>
-                        <div class="card-body">
-                            <div class="table-responsive">
-                                <table class="table table-striped align-middle" id="demandTable" style="width:100%">
-                                    <thead>
-                                        <tr>
-                                            <th>Warehouse</th>
-                                            <th>SKU</th>
-                                            <th>Stock</th>
-                                            <th>Moving Avg</th>
-                                            <th>Days of Cover</th>
-                                            <th>Reorder Qty</th>
-                                            <th class="d-none">Key</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody></tbody>
-                                </table>
+                        <div class="overflow-x-auto">
+                            <table class="w-full text-left" id="demandTable">
+                                <thead>
+                                    <tr class="border-b border-border-light dark:border-border-dark text-sm text-subtext-light dark:text-subtext-dark">
+                                        <th class="p-4">Warehouse</th>
+                                        <th class="p-4">SKU</th>
+                                        <th class="p-4 text-right">Stock</th>
+                                        <th class="p-4 text-right">Moving Avg</th>
+                                        <th class="p-4 text-right">Days of Cover</th>
+                                        <th class="p-4 text-right">Reorder Qty</th>
+                                    </tr>
+                                </thead>
+                                <tbody id="demandTableBody" class="divide-y divide-border-light dark:divide-border-dark"></tbody>
+                            </table>
+                        </div>
+                        <div class="flex flex-col md:flex-row md:justify-between md:items-center gap-2 pt-4 border-t border-border-light dark:border-border-dark mt-4 text-sm text-subtext-light dark:text-subtext-dark">
+                            <div id="tableSummary">No data loaded.</div>
+                            <div>Click a row to view the demand trend.</div>
+                        </div>
+                    </div>
+                    <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+                        <div class="bg-card-light dark:bg-card-dark p-6 rounded-lg shadow-sm border border-border-light dark:border-border-dark">
+                            <h3 class="text-lg font-semibold mb-4">Summary</h3>
+                            <div class="space-y-3">
+                                <div class="flex justify-between items-center">
+                                    <span class="text-subtext-light dark:text-subtext-dark">Total Items</span>
+                                    <span class="text-xl font-bold" id="summaryItems">0</span>
+                                </div>
+                                <div class="flex justify-between items-center">
+                                    <span class="text-subtext-light dark:text-subtext-dark">Total Reorder Qty</span>
+                                    <span class="text-xl font-bold" id="summaryReorder">0</span>
+                                </div>
+                            </div>
+                            <div class="mt-6 h-48">
+                                <canvas id="reorderChart"></canvas>
+                            </div>
+                        </div>
+                        <div class="lg:col-span-2 bg-card-light dark:bg-card-dark p-6 rounded-lg shadow-sm border border-border-light dark:border-border-dark">
+                            <div class="flex justify-between items-start mb-4">
+                                <div>
+                                    <h3 class="text-lg font-semibold">Rolling Demand (Last Window)</h3>
+                                    <p class="text-sm text-subtext-light dark:text-subtext-dark">Select a row in the table to visualize its recent demand trend.</p>
+                                </div>
+                                <div class="flex items-center space-x-2 text-sm text-primary font-medium">
+                                    <div class="w-4 h-1 bg-primary rounded-full"></div>
+                                    <span id="trendSelectedLabel">No SKU selected</span>
+                                </div>
+                            </div>
+                            <div class="h-64">
+                                <canvas id="trendChart"></canvas>
                             </div>
                         </div>
                     </div>
-                </div>
-            </div>
-            <div class="row g-4 align-items-stretch">
-                <div class="col-lg-4 col-xl-3">
-                    <div class="card shadow-sm h-100">
-                        <div class="card-header">
-                            <h5 class="mb-0">Summary</h5>
-                        </div>
-                        <div class="card-body">
-                            <p class="mb-1"><strong>Total Items:</strong> <span id="summaryItems">0</span></p>
-                            <p class="mb-3"><strong>Total Reorder Qty:</strong> <span id="summaryReorder">0</span></p>
-                            <canvas id="reorderChart" height="220"></canvas>
-                        </div>
-                    </div>
-                </div>
-                <div class="col-lg-8 col-xl-9">
-                    <div class="card shadow-sm h-100">
-                        <div class="card-header">
-                            <h5 class="mb-0">Rolling Demand (Last Window)</h5>
-                        </div>
-                        <div class="card-body small">
-                            <p class="text-muted">Select a row in the table to visualize its recent demand trend.</p>
-                            <canvas id="trendChart" height="220"></canvas>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </section>
+                </section>
 
-        <section id="section-imports"<?= $activeSection === 'imports' ? '' : ' class="d-none"' ?>>
-            <div class="row g-4">
-                <div class="col-lg-6">
-                    <div class="card shadow-sm h-100">
-                        <div class="card-header">
-                            <h5 class="mb-0">Upload Daily Sales CSV</h5>
-                        </div>
-                        <div class="card-body">
+                <section id="section-imports" class="<?= $activeSection === 'imports' ? '' : 'hidden' ?> space-y-6">
+                    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+                        <div class="bg-card-light dark:bg-card-dark p-6 rounded-lg shadow-sm border border-border-light dark:border-border-dark">
+                            <div class="flex items-center justify-between mb-4">
+                                <h3 class="text-lg font-semibold">Upload Daily Sales CSV</h3>
+                            </div>
                             <?php if ($salesPreview): ?>
                                 <?php
                                     $salesHeader = is_array($salesPreview['header'] ?? null) ? $salesPreview['header'] : [];
@@ -550,118 +607,112 @@ if ($salesPreview || $stockPreview) {
                                     $salesColumnMap = is_array($salesPreview['column_map'] ?? null) ? $salesPreview['column_map'] : [];
                                     $salesFields = ['sale_date' => 'Sale Date', 'sku' => 'SKU', 'quantity' => 'Quantity'];
                                 ?>
-                                <p class="text-muted">Preview the uploaded file and choose the columns for sale date, SKU, and quantity.</p>
-                                <div class="mb-3 small">
-                                    <div><strong>Warehouse:</strong> <?= htmlspecialchars($salesWarehouseLabel, ENT_QUOTES) ?></div>
-                                    <div><strong>File:</strong> <?= htmlspecialchars((string) ($salesPreview['filename'] ?? 'uploaded.csv'), ENT_QUOTES) ?></div>
-                                    <div><strong>Rows previewed:</strong> <?= $salesSampleCount ?></div>
+                                <p class="text-sm text-subtext-light dark:text-subtext-dark mb-4">Preview the uploaded file and choose the columns for sale date, SKU, and quantity.</p>
+                                <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm text-subtext-light dark:text-subtext-dark mb-4">
+                                    <div><span class="font-medium text-text-light dark:text-text-dark">Warehouse:</span> <?= htmlspecialchars($salesWarehouseLabel, ENT_QUOTES) ?></div>
+                                    <div><span class="font-medium text-text-light dark:text-text-dark">File:</span> <?= htmlspecialchars((string) ($salesPreview['filename'] ?? 'uploaded.csv'), ENT_QUOTES) ?></div>
+                                    <div><span class="font-medium text-text-light dark:text-text-dark">Rows previewed:</span> <?= $salesSampleCount ?></div>
                                 </div>
-                                <form method="post">
+                                <form method="post" class="space-y-4">
                                     <input type="hidden" name="action" value="confirm_sales">
-                                    <div class="row g-3 mb-3">
+                                    <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
                                         <?php foreach ($salesHeader as $index => $columnLabel):
                                             $displayLabel = trim((string) $columnLabel) !== '' ? (string) $columnLabel : 'Column ' . ($index + 1);
                                         ?>
-                                        <div class="col-md-4">
-                                            <div class="border rounded p-3 h-100">
-                                                <div class="small text-muted text-uppercase mb-1">Column <?= $index + 1 ?></div>
-                                                <div class="fw-semibold text-truncate" title="<?= htmlspecialchars($displayLabel, ENT_QUOTES) ?>">
+                                            <div class="border border-border-light dark:border-border-dark rounded-lg p-4">
+                                                <div class="text-xs uppercase tracking-wide text-subtext-light dark:text-subtext-dark mb-1">Column <?= $index + 1 ?></div>
+                                                <div class="font-medium truncate" title="<?= htmlspecialchars($displayLabel, ENT_QUOTES) ?>">
                                                     <?= htmlspecialchars($displayLabel, ENT_QUOTES) ?>
                                                 </div>
-                                                <div class="mt-2">
+                                                <div class="mt-3 space-y-2">
                                                     <?php foreach ($salesFields as $fieldKey => $fieldLabel):
                                                         $checked = isset($salesColumnMap[$fieldKey]) && (int) $salesColumnMap[$fieldKey] === (int) $index;
                                                     ?>
-                                                    <div class="form-check">
-                                                        <input class="form-check-input column-checkbox" type="checkbox" id="sales-<?= $fieldKey ?>-<?= $index ?>" name="column_map[<?= $fieldKey ?>]" value="<?= $index ?>" data-field="<?= $fieldKey ?>" <?= $checked ? 'checked' : '' ?>>
-                                                        <label class="form-check-label small" for="sales-<?= $fieldKey ?>-<?= $index ?>">Use as <?= htmlspecialchars($fieldLabel, ENT_QUOTES) ?></label>
-                                                    </div>
+                                                        <label class="flex items-center space-x-2 text-sm">
+                                                            <input type="checkbox" class="column-checkbox rounded border-border-light dark:border-border-dark text-primary focus:ring-primary" id="sales-<?= $fieldKey ?>-<?= $index ?>" name="column_map[<?= $fieldKey ?>]" value="<?= $index ?>" data-field="<?= $fieldKey ?>" <?= $checked ? 'checked' : '' ?>>
+                                                            <span>Use as <?= htmlspecialchars($fieldLabel, ENT_QUOTES) ?></span>
+                                                        </label>
                                                     <?php endforeach; ?>
                                                 </div>
                                             </div>
-                                        </div>
                                         <?php endforeach; ?>
                                         <?php if (empty($salesHeader)): ?>
-                                        <div class="col-12">
-                                            <div class="alert alert-warning mb-0">No columns detected in the uploaded file.</div>
-                                        </div>
+                                            <div class="sm:col-span-2 lg:col-span-3">
+                                                <div class="rounded-lg border border-yellow-200 bg-yellow-50 px-4 py-3 text-yellow-800">No columns detected in the uploaded file.</div>
+                                            </div>
                                         <?php endif; ?>
                                     </div>
-                                    <div class="table-responsive mb-3">
-                                        <table class="table table-sm table-striped align-middle mb-0">
-                                            <thead>
+                                    <div class="overflow-x-auto border border-border-light dark:border-border-dark rounded-lg">
+                                        <table class="min-w-full text-sm">
+                                            <thead class="bg-background-light dark:bg-background-dark text-subtext-light dark:text-subtext-dark">
                                                 <tr>
                                                     <?php if ($salesHeaderCount > 0): ?>
                                                         <?php foreach ($salesHeader as $columnLabel):
                                                             $headerLabel = trim((string) $columnLabel) !== '' ? (string) $columnLabel : 'Column';
                                                         ?>
-                                                        <th><?= htmlspecialchars($headerLabel, ENT_QUOTES) ?></th>
+                                                            <th class="px-4 py-2 font-medium"><?= htmlspecialchars($headerLabel, ENT_QUOTES) ?></th>
                                                         <?php endforeach; ?>
                                                     <?php else: ?>
-                                                        <th>Data</th>
+                                                        <th class="px-4 py-2 font-medium">Data</th>
                                                     <?php endif; ?>
                                                 </tr>
                                             </thead>
                                             <tbody>
                                                 <?php if ($salesSampleCount > 0): ?>
                                                     <?php foreach ($salesRows as $row): ?>
-                                                    <tr>
-                                                        <?php if ($salesHeaderCount > 0): ?>
-                                                            <?php for ($i = 0; $i < $salesHeaderCount; $i++): ?>
-                                                            <td><?= htmlspecialchars((string) ($row[$i] ?? ''), ENT_QUOTES) ?></td>
-                                                            <?php endfor; ?>
-                                                        <?php else: ?>
-                                                            <td><?= htmlspecialchars(implode(', ', array_map('strval', $row)), ENT_QUOTES) ?></td>
-                                                        <?php endif; ?>
-                                                    </tr>
+                                                        <tr class="border-t border-border-light dark:border-border-dark">
+                                                            <?php if ($salesHeaderCount > 0): ?>
+                                                                <?php for ($i = 0; $i < $salesHeaderCount; $i++): ?>
+                                                                    <td class="px-4 py-2 text-text-light dark:text-text-dark"><?= htmlspecialchars((string) ($row[$i] ?? ''), ENT_QUOTES) ?></td>
+                                                                <?php endfor; ?>
+                                                            <?php else: ?>
+                                                                <td class="px-4 py-2 text-text-light dark:text-text-dark"><?= htmlspecialchars(implode(', ', array_map('strval', $row)), ENT_QUOTES) ?></td>
+                                                            <?php endif; ?>
+                                                        </tr>
                                                     <?php endforeach; ?>
                                                 <?php else: ?>
                                                     <tr>
-                                                        <td colspan="<?= max(1, $salesHeaderCount) ?>" class="text-center text-muted">No data rows detected.</td>
+                                                        <td colspan="<?= max(1, $salesHeaderCount) ?>" class="px-4 py-6 text-center text-subtext-light dark:text-subtext-dark">No data rows detected.</td>
                                                     </tr>
                                                 <?php endif; ?>
                                             </tbody>
                                         </table>
-                                        <p class="text-muted small mt-2 mb-0">Showing the first <?= $salesSampleCount ?> row<?= $salesSampleCount === 1 ? '' : 's' ?> from the file.</p>
+                                        <p class="px-4 py-2 text-xs text-subtext-light dark:text-subtext-dark">Showing the first <?= $salesSampleCount ?> row<?= $salesSampleCount === 1 ? '' : 's' ?> from the file.</p>
                                     </div>
-                                    <div class="d-flex gap-2">
-                                        <button class="btn btn-primary" type="submit">Import Sales</button>
+                                    <div class="flex flex-wrap gap-3">
+                                        <button type="submit" class="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-primary/90 transition">Import Sales</button>
                                     </div>
                                 </form>
                                 <form method="post" class="mt-2">
                                     <input type="hidden" name="action" value="cancel_sales_preview">
-                                    <button class="btn btn-link text-danger p-0" type="submit">Cancel preview</button>
+                                    <button type="submit" class="text-sm font-medium text-red-600 hover:text-red-700">Cancel preview</button>
                                 </form>
                             <?php else: ?>
-                                <p class="text-muted">Upload a CSV for a single warehouse. After the upload you'll choose the columns for date, SKU, and quantity.</p>
-                                <form method="post" enctype="multipart/form-data">
+                                <p class="text-sm text-subtext-light dark:text-subtext-dark mb-4">Upload a CSV for a single warehouse. After the upload you'll choose the columns for date, SKU, and quantity.</p>
+                                <form method="post" enctype="multipart/form-data" class="space-y-4">
                                     <input type="hidden" name="action" value="preview_sales">
-                                    <div class="mb-3">
-                                        <label class="form-label" for="salesWarehouse">Warehouse</label>
-                                        <select class="form-select" id="salesWarehouse" name="warehouse_id" required>
-                                            <option value="">Select warehouse</option>
+                                    <div>
+                                        <label for="salesWarehouse" class="block text-sm font-medium text-subtext-light dark:text-subtext-dark mb-1">Warehouse</label>
+                                        <select id="salesWarehouse" name="warehouse_id" required class="w-full rounded-md border border-border-light dark:border-border-dark bg-background-light dark:bg-background-dark px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary">
+                                            <option value="">Choose...</option>
                                             <?php foreach ($warehouses as $warehouse): ?>
                                                 <option value="<?= (int) $warehouse['id'] ?>"><?= htmlspecialchars($warehouse['code'] . ' · ' . $warehouse['name'], ENT_QUOTES) ?></option>
                                             <?php endforeach; ?>
                                         </select>
                                     </div>
-                                    <div class="mb-3">
-                                        <label class="form-label" for="salesCsv">Daily Sales CSV</label>
-                                        <input class="form-control" type="file" id="salesCsv" name="sales_csv" accept=".csv" required>
-                                        <div class="form-text">Ensure the file includes columns for sale date (YYYY-MM-DD), SKU, and quantity.</div>
+                                    <div>
+                                        <label for="salesCsv" class="block text-sm font-medium text-subtext-light dark:text-subtext-dark mb-1">Sales CSV</label>
+                                        <input type="file" id="salesCsv" name="sales_csv" accept=".csv" required class="w-full text-sm text-subtext-light dark:text-subtext-dark file:mr-4 file:rounded-md file:border-0 file:bg-primary file:px-4 file:py-2 file:text-sm file:font-semibold file:text-white hover:file:bg-primary/90">
+                                        <p class="mt-2 text-xs text-subtext-light dark:text-subtext-dark">Include columns for sale date, SKU, and quantity.</p>
                                     </div>
-                                    <button class="btn btn-primary" type="submit">Preview Sales File</button>
+                                    <button type="submit" class="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-primary/90 transition">Upload &amp; Preview</button>
                                 </form>
                             <?php endif; ?>
                         </div>
-                    </div>
-                </div>
-                <div class="col-lg-6">
-                    <div class="card shadow-sm h-100">
-                        <div class="card-header">
-                            <h5 class="mb-0">Upload Stock Snapshot CSV</h5>
-                        </div>
-                        <div class="card-body">
+                        <div class="bg-card-light dark:bg-card-dark p-6 rounded-lg shadow-sm border border-border-light dark:border-border-dark">
+                            <div class="flex items-center justify-between mb-4">
+                                <h3 class="text-lg font-semibold">Upload Stock Snapshot CSV</h3>
+                            </div>
                             <?php if ($stockPreview): ?>
                                 <?php
                                     $stockHeader = is_array($stockPreview['header'] ?? null) ? $stockPreview['header'] : [];
@@ -673,299 +724,223 @@ if ($salesPreview || $stockPreview) {
                                     $stockWarehouseLabel = $stockWarehouseInfo
                                         ? ($stockWarehouseInfo['code'] . ' · ' . $stockWarehouseInfo['name'])
                                         : ('ID ' . $stockWarehouseId);
+                                    $stockSnapshotDate = (string) ($stockPreview['snapshot_date'] ?? '');
                                     $stockColumnMap = is_array($stockPreview['column_map'] ?? null) ? $stockPreview['column_map'] : [];
                                     $stockFields = ['sku' => 'SKU', 'quantity' => 'Quantity'];
-                                    $stockSnapshotDate = (string) ($stockPreview['snapshot_date'] ?? '');
                                 ?>
-                                <p class="text-muted">Preview the uploaded file and choose the columns for SKU and quantity.</p>
-                                <div class="mb-3 small">
-                                    <div><strong>Warehouse:</strong> <?= htmlspecialchars($stockWarehouseLabel, ENT_QUOTES) ?></div>
-                                    <div><strong>Snapshot date:</strong> <?= htmlspecialchars($stockSnapshotDate, ENT_QUOTES) ?></div>
-                                    <div><strong>File:</strong> <?= htmlspecialchars((string) ($stockPreview['filename'] ?? 'uploaded.csv'), ENT_QUOTES) ?></div>
-                                    <div><strong>Rows previewed:</strong> <?= $stockSampleCount ?></div>
+                                <p class="text-sm text-subtext-light dark:text-subtext-dark mb-4">Preview the uploaded file and choose the columns for SKU and quantity.</p>
+                                <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm text-subtext-light dark:text-subtext-dark mb-4">
+                                    <div><span class="font-medium text-text-light dark:text-text-dark">Warehouse:</span> <?= htmlspecialchars($stockWarehouseLabel, ENT_QUOTES) ?></div>
+                                    <div><span class="font-medium text-text-light dark:text-text-dark">Snapshot date:</span> <?= htmlspecialchars($stockSnapshotDate, ENT_QUOTES) ?></div>
+                                    <div><span class="font-medium text-text-light dark:text-text-dark">File:</span> <?= htmlspecialchars((string) ($stockPreview['filename'] ?? 'uploaded.csv'), ENT_QUOTES) ?></div>
+                                    <div><span class="font-medium text-text-light dark:text-text-dark">Rows previewed:</span> <?= $stockSampleCount ?></div>
                                 </div>
-                                <form method="post">
+                                <form method="post" class="space-y-4">
                                     <input type="hidden" name="action" value="confirm_stock">
-                                    <div class="row g-3 mb-3">
+                                    <div class="grid gap-4 sm:grid-cols-2">
                                         <?php foreach ($stockHeader as $index => $columnLabel):
                                             $displayLabel = trim((string) $columnLabel) !== '' ? (string) $columnLabel : 'Column ' . ($index + 1);
                                         ?>
-                                        <div class="col-md-4">
-                                            <div class="border rounded p-3 h-100">
-                                                <div class="small text-muted text-uppercase mb-1">Column <?= $index + 1 ?></div>
-                                                <div class="fw-semibold text-truncate" title="<?= htmlspecialchars($displayLabel, ENT_QUOTES) ?>">
+                                            <div class="border border-border-light dark:border-border-dark rounded-lg p-4">
+                                                <div class="text-xs uppercase tracking-wide text-subtext-light dark:text-subtext-dark mb-1">Column <?= $index + 1 ?></div>
+                                                <div class="font-medium truncate" title="<?= htmlspecialchars($displayLabel, ENT_QUOTES) ?>">
                                                     <?= htmlspecialchars($displayLabel, ENT_QUOTES) ?>
                                                 </div>
-                                                <div class="mt-2">
+                                                <div class="mt-3 space-y-2">
                                                     <?php foreach ($stockFields as $fieldKey => $fieldLabel):
                                                         $checked = isset($stockColumnMap[$fieldKey]) && (int) $stockColumnMap[$fieldKey] === (int) $index;
                                                     ?>
-                                                    <div class="form-check">
-                                                        <input class="form-check-input column-checkbox" type="checkbox" id="stock-<?= $fieldKey ?>-<?= $index ?>" name="column_map[<?= $fieldKey ?>]" value="<?= $index ?>" data-field="<?= $fieldKey ?>" <?= $checked ? 'checked' : '' ?>>
-                                                        <label class="form-check-label small" for="stock-<?= $fieldKey ?>-<?= $index ?>">Use as <?= htmlspecialchars($fieldLabel, ENT_QUOTES) ?></label>
-                                                    </div>
+                                                        <label class="flex items-center space-x-2 text-sm">
+                                                            <input type="checkbox" class="column-checkbox rounded border-border-light dark:border-border-dark text-primary focus:ring-primary" id="stock-<?= $fieldKey ?>-<?= $index ?>" name="column_map[<?= $fieldKey ?>]" value="<?= $index ?>" data-field="<?= $fieldKey ?>" <?= $checked ? 'checked' : '' ?>>
+                                                            <span>Use as <?= htmlspecialchars($fieldLabel, ENT_QUOTES) ?></span>
+                                                        </label>
                                                     <?php endforeach; ?>
                                                 </div>
                                             </div>
-                                        </div>
                                         <?php endforeach; ?>
                                         <?php if (empty($stockHeader)): ?>
-                                        <div class="col-12">
-                                            <div class="alert alert-warning mb-0">No columns detected in the uploaded file.</div>
-                                        </div>
+                                            <div class="sm:col-span-2">
+                                                <div class="rounded-lg border border-yellow-200 bg-yellow-50 px-4 py-3 text-yellow-800">No columns detected in the uploaded file.</div>
+                                            </div>
                                         <?php endif; ?>
                                     </div>
-                                    <div class="table-responsive mb-3">
-                                        <table class="table table-sm table-striped align-middle mb-0">
-                                            <thead>
+                                    <div class="overflow-x-auto border border-border-light dark:border-border-dark rounded-lg">
+                                        <table class="min-w-full text-sm">
+                                            <thead class="bg-background-light dark:bg-background-dark text-subtext-light dark:text-subtext-dark">
                                                 <tr>
                                                     <?php if ($stockHeaderCount > 0): ?>
                                                         <?php foreach ($stockHeader as $columnLabel):
                                                             $headerLabel = trim((string) $columnLabel) !== '' ? (string) $columnLabel : 'Column';
                                                         ?>
-                                                        <th><?= htmlspecialchars($headerLabel, ENT_QUOTES) ?></th>
+                                                            <th class="px-4 py-2 font-medium"><?= htmlspecialchars($headerLabel, ENT_QUOTES) ?></th>
                                                         <?php endforeach; ?>
                                                     <?php else: ?>
-                                                        <th>Data</th>
+                                                        <th class="px-4 py-2 font-medium">Data</th>
                                                     <?php endif; ?>
                                                 </tr>
                                             </thead>
                                             <tbody>
                                                 <?php if ($stockSampleCount > 0): ?>
                                                     <?php foreach ($stockRows as $row): ?>
-                                                    <tr>
-                                                        <?php if ($stockHeaderCount > 0): ?>
-                                                            <?php for ($i = 0; $i < $stockHeaderCount; $i++): ?>
-                                                            <td><?= htmlspecialchars((string) ($row[$i] ?? ''), ENT_QUOTES) ?></td>
-                                                            <?php endfor; ?>
-                                                        <?php else: ?>
-                                                            <td><?= htmlspecialchars(implode(', ', array_map('strval', $row)), ENT_QUOTES) ?></td>
-                                                        <?php endif; ?>
-                                                    </tr>
+                                                        <tr class="border-t border-border-light dark:border-border-dark">
+                                                            <?php if ($stockHeaderCount > 0): ?>
+                                                                <?php for ($i = 0; $i < $stockHeaderCount; $i++): ?>
+                                                                    <td class="px-4 py-2 text-text-light dark:text-text-dark"><?= htmlspecialchars((string) ($row[$i] ?? ''), ENT_QUOTES) ?></td>
+                                                                <?php endfor; ?>
+                                                            <?php else: ?>
+                                                                <td class="px-4 py-2 text-text-light dark:text-text-dark"><?= htmlspecialchars(implode(', ', array_map('strval', $row)), ENT_QUOTES) ?></td>
+                                                            <?php endif; ?>
+                                                        </tr>
                                                     <?php endforeach; ?>
                                                 <?php else: ?>
                                                     <tr>
-                                                        <td colspan="<?= max(1, $stockHeaderCount) ?>" class="text-center text-muted">No data rows detected.</td>
+                                                        <td colspan="<?= max(1, $stockHeaderCount) ?>" class="px-4 py-6 text-center text-subtext-light dark:text-subtext-dark">No data rows detected.</td>
                                                     </tr>
                                                 <?php endif; ?>
                                             </tbody>
                                         </table>
-                                        <p class="text-muted small mt-2 mb-0">Showing the first <?= $stockSampleCount ?> row<?= $stockSampleCount === 1 ? '' : 's' ?> from the file.</p>
+                                        <p class="px-4 py-2 text-xs text-subtext-light dark:text-subtext-dark">Showing the first <?= $stockSampleCount ?> row<?= $stockSampleCount === 1 ? '' : 's' ?> from the file.</p>
                                     </div>
-                                    <div class="d-flex gap-2">
-                                        <button class="btn btn-primary" type="submit">Import Stock</button>
+                                    <div class="flex flex-wrap gap-3">
+                                        <button type="submit" class="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-primary/90 transition">Import Stock Snapshot</button>
                                     </div>
                                 </form>
                                 <form method="post" class="mt-2">
                                     <input type="hidden" name="action" value="cancel_stock_preview">
-                                    <button class="btn btn-link text-danger p-0" type="submit">Cancel preview</button>
+                                    <button type="submit" class="text-sm font-medium text-red-600 hover:text-red-700">Cancel preview</button>
                                 </form>
                             <?php else: ?>
-                                <p class="text-muted">Upload a snapshot CSV for a single warehouse. After the upload you'll choose the columns for SKU and quantity.</p>
-                                <form method="post" enctype="multipart/form-data">
+                                <p class="text-sm text-subtext-light dark:text-subtext-dark mb-4">Upload the current inventory levels for a warehouse. We'll use it as the starting point for demand calculations.</p>
+                                <form method="post" enctype="multipart/form-data" class="space-y-4">
                                     <input type="hidden" name="action" value="preview_stock">
-                                    <div class="mb-3">
-                                        <label class="form-label" for="stockWarehouse">Warehouse</label>
-                                        <select class="form-select" id="stockWarehouse" name="warehouse_id" required>
-                                            <option value="">Select warehouse</option>
+                                    <div>
+                                        <label for="stockWarehouse" class="block text-sm font-medium text-subtext-light dark:text-subtext-dark mb-1">Warehouse</label>
+                                        <select id="stockWarehouse" name="warehouse_id" required class="w-full rounded-md border border-border-light dark:border-border-dark bg-background-light dark:bg-background-dark px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary">
+                                            <option value="">Choose...</option>
                                             <?php foreach ($warehouses as $warehouse): ?>
                                                 <option value="<?= (int) $warehouse['id'] ?>"><?= htmlspecialchars($warehouse['code'] . ' · ' . $warehouse['name'], ENT_QUOTES) ?></option>
                                             <?php endforeach; ?>
                                         </select>
                                     </div>
-                                    <div class="mb-3">
-                                        <label class="form-label" for="stockSnapshotDate">Snapshot Date</label>
-                                        <input class="form-control" type="date" id="stockSnapshotDate" name="snapshot_date" required>
-                                        <div class="form-text">All rows in the file will be imported with this snapshot date.</div>
+                                    <div>
+                                        <label for="snapshotDate" class="block text-sm font-medium text-subtext-light dark:text-subtext-dark mb-1">Snapshot Date</label>
+                                        <input type="date" id="snapshotDate" name="snapshot_date" required class="w-full rounded-md border border-border-light dark:border-border-dark bg-background-light dark:bg-background-dark px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary">
                                     </div>
-                                    <div class="mb-3">
-                                        <label class="form-label" for="stockCsv">Stock Snapshot CSV</label>
-                                        <input class="form-control" type="file" id="stockCsv" name="stock_csv" accept=".csv" required>
-                                        <div class="form-text">Ensure the file includes columns for SKU and quantity.</div>
+                                    <div>
+                                        <label for="stockCsv" class="block text-sm font-medium text-subtext-light dark:text-subtext-dark mb-1">Stock CSV</label>
+                                        <input type="file" id="stockCsv" name="stock_csv" accept=".csv" required class="w-full text-sm text-subtext-light dark:text-subtext-dark file:mr-4 file:rounded-md file:border-0 file:bg-primary file:px-4 file:py-2 file:text-sm file:font-semibold file:text-white hover:file:bg-primary/90">
+                                        <p class="mt-2 text-xs text-subtext-light dark:text-subtext-dark">Include columns for SKU and quantity on hand.</p>
                                     </div>
-                                    <button class="btn btn-primary" type="submit">Preview Stock File</button>
+                                    <button type="submit" class="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-primary/90 transition">Upload &amp; Preview</button>
                                 </form>
                             <?php endif; ?>
                         </div>
                     </div>
-                </div>
-            </div>
-        </section>
+                </section>
 
-        <section id="section-warehouses"<?= $activeSection === 'warehouses' ? '' : ' class="d-none"' ?>>
-            <div class="row g-4">
-                <div class="col-lg-4">
-                    <div class="card shadow-sm h-100">
-                        <div class="card-header">
-                            <h5 class="mb-0">Add Warehouse</h5>
-                        </div>
-                        <div class="card-body">
-                            <form method="post">
+                <section id="section-warehouses" class="<?= $activeSection === 'warehouses' ? '' : 'hidden' ?> space-y-6">
+                    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+                        <div class="bg-card-light dark:bg-card-dark p-6 rounded-lg shadow-sm border border-border-light dark:border-border-dark">
+                            <h3 class="text-lg font-semibold mb-4">Add or Update Warehouse</h3>
+                            <form method="post" class="space-y-4">
                                 <input type="hidden" name="action" value="add_warehouse">
-                                <div class="mb-3">
-                                    <label class="form-label" for="warehouse_code">Code</label>
-                                    <input class="form-control" type="text" id="warehouse_code" name="warehouse_code" maxlength="50" required>
+                                <div>
+                                    <label for="warehouseCode" class="block text-sm font-medium text-subtext-light dark:text-subtext-dark mb-1">Warehouse Code</label>
+                                    <input type="text" id="warehouseCode" name="warehouse_code" maxlength="50" required class="w-full rounded-md border border-border-light dark:border-border-dark bg-background-light dark:bg-background-dark px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary">
                                 </div>
-                                <div class="mb-3">
-                                    <label class="form-label" for="warehouse_name">Name</label>
-                                    <input class="form-control" type="text" id="warehouse_name" name="warehouse_name" maxlength="120" placeholder="Optional">
+                                <div>
+                                    <label for="warehouseName" class="block text-sm font-medium text-subtext-light dark:text-subtext-dark mb-1">Warehouse Name</label>
+                                    <input type="text" id="warehouseName" name="warehouse_name" maxlength="120" placeholder="Optional" class="w-full rounded-md border border-border-light dark:border-border-dark bg-background-light dark:bg-background-dark px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary">
                                 </div>
-                                <p class="form-text">Codes must be unique. Warehouses are also created automatically during CSV imports.</p>
-                                <button class="btn btn-primary" type="submit">Save Warehouse</button>
+                                <button type="submit" class="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-primary/90 transition">Save Warehouse</button>
                             </form>
                         </div>
-                    </div>
-                </div>
-                <div class="col-lg-8">
-                    <div class="card shadow-sm h-100">
-                        <div class="card-header">
-                            <h5 class="mb-0">Existing Warehouses</h5>
-                        </div>
-                        <div class="card-body p-0">
-                            <div class="table-responsive">
-                                <table class="table table-sm align-middle mb-0">
-                                    <thead>
+                        <div class="bg-card-light dark:bg-card-dark p-6 rounded-lg shadow-sm border border-border-light dark:border-border-dark">
+                            <h3 class="text-lg font-semibold mb-4">Existing Warehouses</h3>
+                            <div class="overflow-x-auto">
+                                <table class="min-w-full text-left text-sm">
+                                    <thead class="border-b border-border-light dark:border-border-dark text-subtext-light dark:text-subtext-dark">
                                         <tr>
-                                            <th>Code</th>
-                                            <th>Name</th>
-                                            <th>Created</th>
+                                            <th class="px-4 py-2">Code</th>
+                                            <th class="px-4 py-2">Name</th>
                                         </tr>
                                     </thead>
                                     <tbody>
-                                        <?php foreach ($warehouses as $warehouse):
-                                            $createdLabel = '—';
-                                            if (!empty($warehouse['created_at'])) {
-                                                try {
-                                                    $createdLabel = (new \DateTimeImmutable($warehouse['created_at']))->format('Y-m-d H:i');
-                                                } catch (\Exception $e) {
-                                                    $createdLabel = $warehouse['created_at'];
-                                                }
-                                            }
-                                        ?>
-                                        <tr>
-                                            <td><?= htmlspecialchars($warehouse['code'], ENT_QUOTES) ?></td>
-                                            <td><?= htmlspecialchars($warehouse['name'], ENT_QUOTES) ?></td>
-                                            <td><?= htmlspecialchars($createdLabel, ENT_QUOTES) ?></td>
-                                        </tr>
-                                        <?php endforeach; ?>
-                                        <?php if (empty($warehouses)): ?>
-                                        <tr>
-                                            <td colspan="3" class="text-center text-muted py-3">No warehouses yet.</td>
-                                        </tr>
+                                        <?php if (!empty($warehouses)): ?>
+                                            <?php foreach ($warehouses as $warehouse): ?>
+                                                <tr class="border-b border-border-light dark:border-border-dark last:border-0">
+                                                    <td class="px-4 py-2 text-text-light dark:text-text-dark"><?= htmlspecialchars($warehouse['code'], ENT_QUOTES) ?></td>
+                                                    <td class="px-4 py-2 text-text-light dark:text-text-dark"><?= htmlspecialchars($warehouse['name'], ENT_QUOTES) ?></td>
+                                                </tr>
+                                            <?php endforeach; ?>
+                                        <?php else: ?>
+                                            <tr>
+                                                <td colspan="2" class="px-4 py-6 text-center text-subtext-light dark:text-subtext-dark">No warehouses available.</td>
+                                            </tr>
                                         <?php endif; ?>
                                     </tbody>
                                 </table>
                             </div>
                         </div>
                     </div>
-                </div>
-            </div>
-        </section>
+                </section>
 
-        <section id="section-parameters"<?= $activeSection === 'parameters' ? '' : ' class="d-none"' ?>>
-            <div class="row g-4">
-                <div class="col-12 col-xl-8 col-xxl-7">
-                    <div class="card shadow-sm h-100">
-                        <div class="card-header">
-                            <h5 class="mb-0">Edit Parameters</h5>
-                        </div>
-                        <div class="card-body">
-                            <form class="row g-3" method="post">
+                <section id="section-parameters" class="<?= $activeSection === 'parameters' ? '' : 'hidden' ?> space-y-6">
+                    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+                        <div class="bg-card-light dark:bg-card-dark p-6 rounded-lg shadow-sm border border-border-light dark:border-border-dark">
+                            <h3 class="text-lg font-semibold mb-4">Warehouse Parameters</h3>
+                            <form method="post" class="space-y-4">
                                 <input type="hidden" name="action" value="save_parameters">
-                                <div class="col-md-6">
-                                    <label class="form-label" for="paramWarehouse">Warehouse</label>
-                                    <select class="form-select" id="paramWarehouse" name="warehouse_id" required>
-                                        <option value="">Select warehouse</option>
-                                        <?php foreach ($warehouses as $warehouse): ?>
-                                            <option value="<?= (int) $warehouse['id'] ?>"><?= htmlspecialchars($warehouse['code'] . ' · ' . $warehouse['name'], ENT_QUOTES) ?></option>
+                                <div>
+                                    <label for="paramWarehouse" class="block text-sm font-medium text-subtext-light dark:text-subtext-dark mb-1">Warehouse</label>
+                                    <select id="paramWarehouse" name="warehouse_id" required class="w-full rounded-md border border-border-light dark:border-border-dark bg-background-light dark:bg-background-dark px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary">
+                                        <option value="">Choose...</option>
+                                        <?php foreach ($warehouses as $warehouse):
+                                            $warehouseId = (int) $warehouse['id'];
+                                            $params = $warehouseParams[$warehouseId] ?? $defaults;
+                                        ?>
+                                            <option value="<?= $warehouseId ?>" data-params='<?= json_encode($params, JSON_THROW_ON_ERROR) ?>'><?= htmlspecialchars($warehouse['code'] . ' · ' . $warehouse['name'], ENT_QUOTES) ?></option>
                                         <?php endforeach; ?>
                                     </select>
                                 </div>
-                                <div class="col-md-6">
-                                    <label class="form-label" for="paramSku">SKU Override <span class="text-muted">(optional)</span></label>
-                                    <input class="form-control" type="text" id="paramSku" name="sku" placeholder="Leave blank for warehouse default">
+                                <div>
+                                    <label for="paramSku" class="block text-sm font-medium text-subtext-light dark:text-subtext-dark mb-1">SKU Override (optional)</label>
+                                    <input type="text" id="paramSku" name="sku" placeholder="Enter SKU to override" class="w-full rounded-md border border-border-light dark:border-border-dark bg-background-light dark:bg-background-dark px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary">
                                 </div>
-                                <div class="col-md-3">
-                                    <label class="form-label" for="paramDaysCover">Days to Cover</label>
-                                    <input class="form-control" type="number" min="1" id="paramDaysCover" name="days_to_cover" value="<?= (int) $defaults['days_to_cover'] ?>" required>
+                                <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                                    <div>
+                                        <label for="paramDaysCover" class="block text-sm font-medium text-subtext-light dark:text-subtext-dark mb-1">Days to Cover</label>
+                                        <input type="number" min="0" step="1" id="paramDaysCover" name="days_to_cover" value="<?= (int) $defaults['days_to_cover'] ?>" required class="w-full rounded-md border border-border-light dark:border-border-dark bg-background-light dark:bg-background-dark px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary">
+                                    </div>
+                                    <div>
+                                        <label for="paramWindow" class="block text-sm font-medium text-subtext-light dark:text-subtext-dark mb-1">MA Window (days)</label>
+                                        <input type="number" min="1" step="1" id="paramWindow" name="ma_window_days" value="<?= (int) $defaults['ma_window_days'] ?>" required class="w-full rounded-md border border-border-light dark:border-border-dark bg-background-light dark:bg-background-dark px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary">
+                                    </div>
+                                    <div>
+                                        <label for="paramMinAvg" class="block text-sm font-medium text-subtext-light dark:text-subtext-dark mb-1">Min Avg Daily</label>
+                                        <input type="number" min="0" step="0.01" id="paramMinAvg" name="min_avg_daily" value="<?= htmlspecialchars(number_format((float) $defaults['min_avg_daily'], 2, '.', ''), ENT_QUOTES) ?>" required class="w-full rounded-md border border-border-light dark:border-border-dark bg-background-light dark:bg-background-dark px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary">
+                                    </div>
+                                    <div>
+                                        <label for="paramSafety" class="block text-sm font-medium text-subtext-light dark:text-subtext-dark mb-1">Safety Days</label>
+                                        <input type="number" min="0" step="0.01" id="paramSafety" name="safety_days" value="<?= htmlspecialchars(number_format((float) $defaults['safety_days'], 2, '.', ''), ENT_QUOTES) ?>" required class="w-full rounded-md border border-border-light dark:border-border-dark bg-background-light dark:bg-background-dark px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary">
+                                    </div>
                                 </div>
-                                <div class="col-md-3">
-                                    <label class="form-label" for="paramWindow">MA Window (days)</label>
-                                    <input class="form-control" type="number" min="1" id="paramWindow" name="ma_window_days" value="<?= (int) $defaults['ma_window_days'] ?>" required>
-                                </div>
-                                <div class="col-md-3">
-                                    <label class="form-label" for="paramMinAvg">Min Avg Daily</label>
-                                    <input class="form-control" type="number" step="0.01" min="0" id="paramMinAvg" name="min_avg_daily" value="<?= htmlspecialchars((string) $defaults['min_avg_daily'], ENT_QUOTES) ?>" required>
-                                </div>
-                                <div class="col-md-3">
-                                    <label class="form-label" for="paramSafety">Safety Days</label>
-                                    <input class="form-control" type="number" step="0.01" min="0" id="paramSafety" name="safety_days" value="<?= htmlspecialchars((string) $defaults['safety_days'], ENT_QUOTES) ?>" required>
-                                </div>
-                                <div class="col-12">
-                                    <button class="btn btn-primary" type="submit">Save Parameters</button>
-                                </div>
+                                <button type="submit" class="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-primary/90 transition">Save Parameters</button>
                             </form>
                         </div>
-                    </div>
-                </div>
-            </div>
-
-            <div class="row g-4 mt-1">
-                <div class="col-lg-6">
-                    <div class="card shadow-sm h-100">
-                        <div class="card-header">
-                            <h5 class="mb-0">Warehouse Parameters</h5>
-                        </div>
-                        <div class="card-body p-0">
-                            <div class="table-responsive">
-                                <table class="table table-sm align-middle mb-0">
-                                    <thead>
+                        <div class="bg-card-light dark:bg-card-dark p-6 rounded-lg shadow-sm border border-border-light dark:border-border-dark">
+                            <h3 class="text-lg font-semibold mb-4">SKU Overrides</h3>
+                            <div class="overflow-x-auto">
+                                <table class="min-w-full text-left text-sm">
+                                    <thead class="border-b border-border-light dark:border-border-dark text-subtext-light dark:text-subtext-dark">
                                         <tr>
-                                            <th>Warehouse</th>
-                                            <th>Days to Cover</th>
-                                            <th>MA Window</th>
-                                            <th>Min Avg</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        <?php foreach ($warehouses as $warehouse):
-                                            $params = $warehouseParams[$warehouse['id']] ?? $defaults;
-                                        ?>
-                                        <tr>
-                                            <td><?= htmlspecialchars($warehouse['code'] . ' · ' . $warehouse['name'], ENT_QUOTES) ?></td>
-                                            <td><?= (int) $params['days_to_cover'] ?></td>
-                                            <td><?= (int) $params['ma_window_days'] ?></td>
-                                            <td><?= htmlspecialchars(number_format((float) $params['min_avg_daily'], 2), ENT_QUOTES) ?></td>
-                                        </tr>
-                                        <?php endforeach; ?>
-                                        <?php if (empty($warehouses)): ?>
-                                        <tr>
-                                            <td colspan="4" class="text-center text-muted py-3">No warehouses yet.</td>
-                                        </tr>
-                                        <?php endif; ?>
-                                    </tbody>
-                                </table>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="col-lg-6">
-                    <div class="card shadow-sm h-100">
-                        <div class="card-header">
-                            <h5 class="mb-0">SKU Overrides</h5>
-                        </div>
-                        <div class="card-body p-0">
-                            <div class="table-responsive">
-                                <table class="table table-sm align-middle mb-0">
-                                    <thead>
-                                        <tr>
-                                            <th>Warehouse</th>
-                                            <th>SKU</th>
-                                            <th>Days to Cover</th>
-                                            <th>MA Window</th>
-                                            <th>Min Avg</th>
-                                            <th>Safety Days</th>
-                                            <th></th>
+                                            <th class="px-4 py-2">Warehouse</th>
+                                            <th class="px-4 py-2">SKU</th>
+                                            <th class="px-4 py-2">Days to Cover</th>
+                                            <th class="px-4 py-2">MA Window</th>
+                                            <th class="px-4 py-2">Min Avg</th>
+                                            <th class="px-4 py-2">Safety Days</th>
+                                            <th class="px-4 py-2"></th>
                                         </tr>
                                     </thead>
                                     <tbody>
@@ -976,19 +951,19 @@ if ($salesPreview || $stockPreview) {
                                                     continue;
                                                 }
                                                 foreach ($items as $skuCode => $params): ?>
-                                                    <tr>
-                                                        <td><?= htmlspecialchars($warehouse['code'], ENT_QUOTES) ?></td>
-                                                        <td><?= htmlspecialchars($skuCode, ENT_QUOTES) ?></td>
-                                                        <td><?= (int) $params['days_to_cover'] ?></td>
-                                                        <td><?= (int) $params['ma_window_days'] ?></td>
-                                                        <td><?= htmlspecialchars(number_format((float) $params['min_avg_daily'], 2), ENT_QUOTES) ?></td>
-                                                        <td><?= htmlspecialchars(number_format((float) $params['safety_days'], 2), ENT_QUOTES) ?></td>
-                                                        <td>
-                                                            <form method="post" class="d-inline">
+                                                    <tr class="border-b border-border-light dark:border-border-dark last:border-0">
+                                                        <td class="px-4 py-2 text-text-light dark:text-text-dark"><?= htmlspecialchars($warehouse['code'], ENT_QUOTES) ?></td>
+                                                        <td class="px-4 py-2 text-text-light dark:text-text-dark"><?= htmlspecialchars($skuCode, ENT_QUOTES) ?></td>
+                                                        <td class="px-4 py-2 text-text-light dark:text-text-dark"><?= (int) $params['days_to_cover'] ?></td>
+                                                        <td class="px-4 py-2 text-text-light dark:text-text-dark"><?= (int) $params['ma_window_days'] ?></td>
+                                                        <td class="px-4 py-2 text-text-light dark:text-text-dark"><?= htmlspecialchars(number_format((float) $params['min_avg_daily'], 2), ENT_QUOTES) ?></td>
+                                                        <td class="px-4 py-2 text-text-light dark:text-text-dark"><?= htmlspecialchars(number_format((float) $params['safety_days'], 2), ENT_QUOTES) ?></td>
+                                                        <td class="px-4 py-2 text-right">
+                                                            <form method="post" class="inline">
                                                                 <input type="hidden" name="action" value="delete_sku_param">
                                                                 <input type="hidden" name="warehouse_id" value="<?= (int) $warehouseId ?>">
                                                                 <input type="hidden" name="sku" value="<?= htmlspecialchars($skuCode, ENT_QUOTES) ?>">
-                                                                <button class="btn btn-link btn-sm text-danger" type="submit">Remove</button>
+                                                                <button type="submit" class="text-sm font-medium text-red-600 hover:text-red-700">Remove</button>
                                                             </form>
                                                         </td>
                                                     </tr>
@@ -996,7 +971,7 @@ if ($salesPreview || $stockPreview) {
                                             endforeach;
                                         else: ?>
                                             <tr>
-                                                <td colspan="7" class="text-center text-muted py-3">No SKU overrides configured.</td>
+                                                <td colspan="7" class="px-4 py-6 text-center text-subtext-light dark:text-subtext-dark">No SKU overrides configured.</td>
                                             </tr>
                                         <?php endif; ?>
                                     </tbody>
@@ -1004,147 +979,232 @@ if ($salesPreview || $stockPreview) {
                             </div>
                         </div>
                     </div>
-                </div>
-            </div>
-        </section>
-    <?php endif; ?>
+                </section>
+            <?php endif; ?>
+        </div>
+    </main>
 </div>
 
-<script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-<script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
-<script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
 <script>
     const sections = document.querySelectorAll('section[id^="section-"]');
-    document.querySelectorAll('#dashboardTabs .nav-link').forEach((btn) => {
-        btn.addEventListener('click', () => {
-            document.querySelectorAll('#dashboardTabs .nav-link').forEach((link) => link.classList.remove('active'));
-            btn.classList.add('active');
-            const sectionId = 'section-' + btn.dataset.section;
+    const navButtons = document.querySelectorAll('#dashboardTabs button[data-section]');
+    navButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+            navButtons.forEach((btn) => btn.classList.remove('bg-primary', 'text-white', 'shadow'));
+            navButtons.forEach((btn) => btn.classList.add('text-subtext-light', 'dark:text-subtext-dark'));
+            button.classList.add('bg-primary', 'text-white', 'shadow');
+            button.classList.remove('text-subtext-light', 'dark:text-subtext-dark');
+
             sections.forEach((section) => {
-                if (section.id === sectionId) {
-                    section.classList.remove('d-none');
+                if (section.id === `section-${button.dataset.section}`) {
+                    section.classList.remove('hidden');
                 } else {
-                    section.classList.add('d-none');
+                    section.classList.add('hidden');
                 }
             });
         });
     });
 
-    let demandTable;
     let reorderChart;
     let trendChart;
     let currentRowsMap = new Map();
+    let selectedRowKey = null;
 
-    function refreshDashboard() {
-        const warehouseId = document.getElementById('warehouseFilter').value;
-        const skuFilter = document.getElementById('skuFilter').value.trim();
-        const params = new URLSearchParams();
-        if (warehouseId) params.append('warehouse_id', warehouseId);
-        if (skuFilter) params.append('sku', skuFilter);
-
-        const query = params.toString();
-        const url = 'api.php' + (query ? '?' + query : '');
-        fetch(url, { credentials: 'same-origin' })
-            .then((response) => response.json())
-            .then((payload) => {
-                const rows = payload.data || [];
-                currentRowsMap = new Map();
-                demandTable.clear();
-                rows.forEach((row) => {
-                    const key = `${row.warehouse_id}|${row.sku}`;
-                    currentRowsMap.set(key, row);
-                    demandTable.row.add([
-                        `${row.warehouse_code} · ${row.warehouse_name}`,
-                        row.sku,
-                        row.current_stock,
-                        row.moving_average,
-                        row.days_of_cover,
-                        row.reorder_qty,
-                        key,
-                    ]);
-                });
-                demandTable.draw();
-
-                document.getElementById('summaryItems').textContent = rows.length;
-                const totalReorder = rows.reduce((sum, row) => {
-                    const value = Number(row.reorder_qty);
-                    return Number.isFinite(value) ? sum + value : sum;
-                }, 0);
-                document.getElementById('summaryReorder').textContent = Math.round(totalReorder)
-                    .toLocaleString('en-GB', { maximumFractionDigits: 0 });
-
-                const topRows = [...rows].sort((a, b) => b.reorder_qty - a.reorder_qty).slice(0, 10);
-                const labels = topRows.map((row) => `${row.warehouse_code}-${row.sku}`);
-                const values = topRows.map((row) => row.reorder_qty);
-
-                if (reorderChart) {
-                    reorderChart.destroy();
-                }
-                const ctx = document.getElementById('reorderChart');
-                reorderChart = new Chart(ctx, {
-                    type: 'bar',
-                    data: {
-                        labels,
-                        datasets: [{
-                            label: 'Reorder Qty',
-                            data: values,
-                            backgroundColor: '#00979d',
-                        }],
-                    },
-                    options: {
-                        responsive: true,
-                        scales: {
-                            y: { beginAtZero: true },
-                        },
-                    },
-                });
-
-                const summaryBody = document.getElementById('summaryItems').closest('.card-body');
-                if (summaryBody) {
-                    summaryBody.classList.toggle('text-muted', rows.length === 0);
-                }
-
-                if (trendChart) {
-                    trendChart.destroy();
-                }
-                renderTrendSeries();
-
-                $('#demandTable tbody').off('click').on('click', 'tr', function () {
-                    const data = demandTable.row(this).data();
-                    if (!data) return;
-                    const key = data[6];
-                    const detail = currentRowsMap.get(key);
-                    if (!detail) return;
-                    renderTrendSeries(detail);
-                });
-            })
-            .catch((error) => {
-                console.error('Failed to load dashboard data', error);
-            });
+    function formatInteger(value) {
+        const number = Number(value);
+        if (!Number.isFinite(number)) {
+            return '0';
+        }
+        return Math.round(number).toLocaleString();
     }
 
-    function renderTrendSeries(row) {
+    function formatDecimal(value) {
+        const number = Number(value);
+        if (!Number.isFinite(number)) {
+            return '0.00';
+        }
+        return number.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+    }
+
+    function createDaysBadge(value) {
+        const span = document.createElement('span');
+        span.className = 'px-2 py-1 text-xs font-semibold rounded-full';
+        const number = Number(value);
+        if (!Number.isFinite(number)) {
+            span.textContent = '—';
+            span.classList.add('bg-gray-200', 'text-gray-600');
+            return span;
+        }
+        if (number <= 0) {
+            span.classList.add('bg-red-100', 'text-red-800');
+        } else if (number <= 5) {
+            span.classList.add('bg-yellow-100', 'text-yellow-800');
+        } else {
+            span.classList.add('bg-green-100', 'text-green-800');
+        }
+        span.textContent = formatInteger(number);
+        return span;
+    }
+
+    function renderTable(rows) {
+        const tbody = document.getElementById('demandTableBody');
+        if (!tbody) {
+            return;
+        }
+        tbody.innerHTML = '';
+        if (rows.length === 0) {
+            const emptyRow = document.createElement('tr');
+            const cell = document.createElement('td');
+            cell.colSpan = 6;
+            cell.className = 'p-6 text-center text-subtext-light dark:text-subtext-dark';
+            cell.textContent = 'No data available for the selected filters.';
+            emptyRow.appendChild(cell);
+            tbody.appendChild(emptyRow);
+            selectedRowKey = null;
+            updateTrendChart(null);
+            document.getElementById('tableSummary').textContent = 'No data loaded.';
+            return;
+        }
+
+        rows.forEach((row) => {
+            const key = `${row.warehouse_id}|${row.sku}`;
+            const tr = document.createElement('tr');
+            tr.dataset.rowKey = key;
+            tr.className = 'cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800/50 transition';
+
+            const warehouseCell = document.createElement('td');
+            warehouseCell.className = 'p-4 whitespace-nowrap';
+            warehouseCell.textContent = `${row.warehouse_code} · ${row.warehouse_name}`;
+            tr.appendChild(warehouseCell);
+
+            const skuCell = document.createElement('td');
+            skuCell.className = 'p-4 whitespace-nowrap font-medium text-primary';
+            skuCell.textContent = row.sku;
+            tr.appendChild(skuCell);
+
+            const stockCell = document.createElement('td');
+            stockCell.className = 'p-4 whitespace-nowrap text-right';
+            stockCell.textContent = formatInteger(row.current_stock);
+            tr.appendChild(stockCell);
+
+            const movingAvgCell = document.createElement('td');
+            movingAvgCell.className = 'p-4 whitespace-nowrap text-right';
+            movingAvgCell.textContent = formatDecimal(row.moving_average);
+            tr.appendChild(movingAvgCell);
+
+            const daysCell = document.createElement('td');
+            daysCell.className = 'p-4 whitespace-nowrap text-right';
+            daysCell.appendChild(createDaysBadge(row.days_of_cover));
+            tr.appendChild(daysCell);
+
+            const reorderCell = document.createElement('td');
+            reorderCell.className = 'p-4 whitespace-nowrap text-right font-bold';
+            reorderCell.textContent = formatInteger(row.reorder_qty);
+            tr.appendChild(reorderCell);
+
+            tr.addEventListener('click', () => {
+                selectedRowKey = key;
+                updateRowSelection();
+                updateTrendChart(key);
+            });
+
+            tbody.appendChild(tr);
+        });
+
+        if (!selectedRowKey || !currentRowsMap.has(selectedRowKey)) {
+            selectedRowKey = `${rows[0].warehouse_id}|${rows[0].sku}`;
+        }
+        updateRowSelection();
+        updateTrendChart(selectedRowKey);
+
+        const summary = document.getElementById('tableSummary');
+        if (summary) {
+            summary.textContent = `Showing ${rows.length} item${rows.length === 1 ? '' : 's'}.`;
+        }
+    }
+
+    function updateRowSelection() {
+        const tbody = document.getElementById('demandTableBody');
+        if (!tbody) {
+            return;
+        }
+        tbody.querySelectorAll('tr').forEach((row) => {
+            row.classList.remove('bg-primary/5', 'dark:bg-primary/10', 'border-l-4', 'border-primary');
+            if (row.dataset.rowKey === selectedRowKey) {
+                row.classList.add('bg-primary/5', 'dark:bg-primary/10', 'border-l-4', 'border-primary');
+            }
+        });
+    }
+
+    function updateSummary(rows) {
+        const itemsEl = document.getElementById('summaryItems');
+        const reorderEl = document.getElementById('summaryReorder');
+        if (!itemsEl || !reorderEl) {
+            return;
+        }
+        itemsEl.textContent = rows.length.toLocaleString();
+        const totalReorder = rows.reduce((sum, row) => {
+            const value = Number(row.reorder_qty);
+            return Number.isFinite(value) ? sum + value : sum;
+        }, 0);
+        reorderEl.textContent = Math.round(totalReorder).toLocaleString();
+    }
+
+    function updateReorderChart(rows) {
+        const ctx = document.getElementById('reorderChart');
+        if (!ctx) {
+            return;
+        }
+        const topRows = [...rows]
+            .sort((a, b) => Number(b.reorder_qty || 0) - Number(a.reorder_qty || 0))
+            .slice(0, 5);
+        const labels = topRows.map((row) => `${row.warehouse_code}-${row.sku}`);
+        const values = topRows.map((row) => Number(row.reorder_qty) || 0);
+
+        if (reorderChart) {
+            reorderChart.destroy();
+        }
+        reorderChart = new Chart(ctx, {
+            type: 'bar',
+            data: {
+                labels,
+                datasets: [{
+                    label: 'Reorder Quantity',
+                    data: values,
+                    backgroundColor: '#007BFF'
+                }]
+            },
+            options: {
+                scales: {
+                    y: {
+                        beginAtZero: true
+                    }
+                }
+            }
+        });
+    }
+
+    function updateTrendChart(rowKey) {
         const ctx = document.getElementById('trendChart');
+        const labelEl = document.getElementById('trendSelectedLabel');
+        if (!ctx || !labelEl) {
+            return;
+        }
         if (trendChart) {
             trendChart.destroy();
         }
-        if (!row) {
+        if (!rowKey || !currentRowsMap.has(rowKey)) {
+            labelEl.textContent = 'No SKU selected';
             trendChart = new Chart(ctx, {
                 type: 'line',
-                data: {
-                    labels: [],
-                    datasets: [{ data: [], borderColor: '#006F7A', tension: 0.3, fill: false }],
-                },
-                options: {
-                    scales: {
-                        y: { beginAtZero: true },
-                    },
-                },
+                data: { labels: [], datasets: [{ data: [], borderColor: '#007BFF', tension: 0.3, fill: false }] },
+                options: { scales: { y: { beginAtZero: true } } }
             });
             return;
         }
+        const row = currentRowsMap.get(rowKey);
+        labelEl.textContent = `${row.warehouse_code}-${row.sku}`;
         const labels = Object.keys(row.daily_series || {});
         const values = labels.map((date) => row.daily_series[date]);
         trendChart = new Chart(ctx, {
@@ -1154,18 +1214,46 @@ if ($salesPreview || $stockPreview) {
                 datasets: [{
                     label: `${row.warehouse_code}-${row.sku}`,
                     data: values,
-                    borderColor: '#006F7A',
-                    backgroundColor: 'rgba(0, 151, 157, 0.2)',
+                    borderColor: '#007BFF',
+                    backgroundColor: 'rgba(0, 123, 255, 0.15)',
                     tension: 0.3,
-                    fill: true,
-                }],
+                    fill: true
+                }]
             },
             options: {
                 scales: {
-                    y: { beginAtZero: true },
-                },
-            },
+                    y: { beginAtZero: true }
+                }
+            }
         });
+    }
+
+    function refreshDashboard() {
+        const warehouseId = document.getElementById('warehouseFilter');
+        const skuFilter = document.getElementById('skuFilter');
+        if (!warehouseId || !skuFilter) {
+            return;
+        }
+        const params = new URLSearchParams();
+        if (warehouseId.value) params.append('warehouse_id', warehouseId.value);
+        if (skuFilter.value.trim()) params.append('sku', skuFilter.value.trim());
+
+        const url = 'api.php' + (params.toString() ? `?${params.toString()}` : '');
+        fetch(url, { credentials: 'same-origin' })
+            .then((response) => response.json())
+            .then((payload) => {
+                const rows = payload.data || [];
+                currentRowsMap = new Map(rows.map((row) => [`${row.warehouse_id}|${row.sku}`, row]));
+                renderTable(rows);
+                updateSummary(rows);
+                updateReorderChart(rows);
+            })
+            .catch(() => {
+                const summary = document.getElementById('tableSummary');
+                if (summary) {
+                    summary.textContent = 'Unable to load dashboard data.';
+                }
+            });
     }
 
     function setupColumnCheckboxes() {
@@ -1187,68 +1275,18 @@ if ($salesPreview || $stockPreview) {
         });
     }
 
-    $(document).ready(function () {
-        const decimalRenderer = $.fn.dataTable.render.number(',', '.', 2);
-        const integerRenderer = $.fn.dataTable.render.number(',', '.', 0);
-        demandTable = $('#demandTable').DataTable({
-            paging: true,
-            searching: false,
-            info: false,
-            order: [[5, 'desc']],
-            columnDefs: [
-                {
-                    targets: [2, 5],
-                    render: function (data) {
-                        if (data === null || data === '') {
-                            return '0';
-                        }
-                        const numericValue = Number(data);
-                        if (!Number.isFinite(numericValue)) {
-                            return '0';
-                        }
-                        return integerRenderer.display(Math.round(numericValue));
-                    },
-                },
-                {
-                    targets: 4,
-                    render: function (data) {
-                        if (data === null || data === '') {
-                            return '—';
-                        }
-                        const numericValue = Number(data);
-                        if (!Number.isFinite(numericValue)) {
-                            return '—';
-                        }
-                        return integerRenderer.display(Math.round(numericValue));
-                    },
-                },
-                {
-                    targets: 3,
-                    render: function (data) {
-                        if (data === null || data === '') {
-                            return '0.00';
-                        }
-                        const numericValue = Number(data);
-                        if (!Number.isFinite(numericValue)) {
-                            return '0.00';
-                        }
-                        return decimalRenderer.display(numericValue);
-                    },
-                },
-                {
-                    targets: 6,
-                    visible: false,
-                    searchable: false,
-                },
-            ],
-        });
-
-        document.getElementById('warehouseFilter').addEventListener('change', refreshDashboard);
-        document.getElementById('skuFilter').addEventListener('input', function () {
-            clearTimeout(this._timer);
-            this._timer = setTimeout(refreshDashboard, 400);
-        });
-
+    document.addEventListener('DOMContentLoaded', () => {
+        const warehouseFilter = document.getElementById('warehouseFilter');
+        const skuFilter = document.getElementById('skuFilter');
+        if (warehouseFilter) {
+            warehouseFilter.addEventListener('change', refreshDashboard);
+        }
+        if (skuFilter) {
+            skuFilter.addEventListener('input', () => {
+                clearTimeout(skuFilter._timer);
+                skuFilter._timer = setTimeout(refreshDashboard, 400);
+            });
+        }
         refreshDashboard();
         setupColumnCheckboxes();
     });


### PR DESCRIPTION
## Summary
- replace the Bootstrap layout with the shared Tailwind dashboard shell, including the new header, alerts, and navigation tabs
- restyle the dashboard table, summary cards, and charts markup to match the provided design and drive them with vanilla JS
- update the data import, warehouse management, and parameter forms to use the new Tailwind components

## Testing
- php -l public/index.php

------
https://chatgpt.com/codex/tasks/task_e_68de8412d24c832780b038b97156b0d9