### PR TITLE
Add loading spinner for dashboard data refresh

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -42,3 +42,18 @@ body {
         transform: translateY(0);
     }
 }
+
+.loading-spinner {
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 9999px;
+    border: 3px solid rgba(15, 145, 189, 0.25);
+    border-top-color: #0f91bd;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
+}


### PR DESCRIPTION
## Summary
- add a loading state indicator above the demand table so users see a spinner while dashboard data loads
- hide the table while loading and restore it when data arrives for clearer feedback
- add reusable spinner styling and tie the fetch flow to the new loading helper

## Testing
- php -l public/index.php

------
https://chatgpt.com/codex/tasks/task_e_68dfb36cf17c83279a744f9040504ee3