### PR TITLE
Keep demand table visible while dashboard reloads

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -602,8 +602,14 @@ $tabs = [
                                         <input id="skuFilter" type="text" placeholder="Filter by SKU" class="<?= $inputClass ?> sm:w-48">
                                     </div>
                                 </div>
-                                <div class="mt-6 overflow-hidden rounded-2xl border border-white/10 bg-white/[0.02] shadow-lg shadow-black/30">
-                                    <div class="overflow-x-auto">
+                                <div id="demandTableContainer" class="mt-6 overflow-hidden rounded-2xl border border-white/10 bg-white/[0.02] shadow-lg shadow-black/30">
+                                    <div id="dashboardLoading" class="hidden px-6 py-10 text-center text-sm text-gray-400" role="status" aria-live="polite" aria-hidden="true">
+                                        <div class="flex flex-col items-center justify-center gap-3">
+                                            <span class="loading-spinner" aria-hidden="true"></span>
+                                            <span>Loading latest demand data&hellip;</span>
+                                        </div>
+                                    </div>
+                                    <div id="demandTableScroll" class="overflow-x-auto">
                                         <table id="demandTable" class="w-full min-w-[960px] table-auto text-sm text-gray-200">
                                             <thead class="bg-white/[0.03] text-xs font-medium uppercase tracking-[0.3em] text-gray-400">
                                                 <tr>
@@ -1269,6 +1275,44 @@ $tabs = [
             return integerFormatter.format(Math.round(numericValue));
         }
 
+        function setDashboardLoading(isLoading) {
+            const loadingEl = document.getElementById('dashboardLoading');
+            const tableScroll = document.getElementById('demandTableScroll');
+            const tableContainer = document.getElementById('demandTableContainer');
+            const tableBody = document.querySelector('#demandTable tbody');
+            const hasRows = !!(tableBody && tableBody.children.length > 0);
+
+            if (loadingEl) {
+                if (isLoading) {
+                    loadingEl.classList.remove('hidden');
+                    loadingEl.setAttribute('aria-hidden', 'false');
+                } else {
+                    loadingEl.classList.add('hidden');
+                    loadingEl.setAttribute('aria-hidden', 'true');
+                }
+            }
+
+            if (tableScroll) {
+                if (isLoading && !hasRows) {
+                    tableScroll.classList.add('hidden');
+                } else {
+                    tableScroll.classList.remove('hidden');
+                }
+            }
+
+            if (tableContainer) {
+                tableContainer.setAttribute('aria-busy', isLoading ? 'true' : 'false');
+                tableContainer.classList.toggle('is-loading', isLoading && hasRows);
+            }
+
+            if (isLoading) {
+                const emptyState = document.getElementById('demandEmptyState');
+                if (emptyState) {
+                    emptyState.classList.add('hidden');
+                }
+            }
+        }
+
         function refreshDashboard() {
             const warehouseSelect = document.getElementById('warehouseFilter');
             const skuInput = document.getElementById('skuFilter');
@@ -1279,6 +1323,8 @@ $tabs = [
             if (warehouseSelect.value) params.append('warehouse_id', warehouseSelect.value);
             if (skuInput.value.trim()) params.append('sku', skuInput.value.trim());
             const url = 'api.php' + (params.toString() ? `?${params.toString()}` : '');
+
+            setDashboardLoading(true);
 
             fetch(url, { credentials: 'same-origin' })
                 .then((response) => response.json())
@@ -1375,6 +1421,9 @@ $tabs = [
                 })
                 .catch((error) => {
                     console.error('Failed to load dashboard data', error);
+                })
+                .finally(() => {
+                    setDashboardLoading(false);
                 });
         }
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -42,3 +42,24 @@ body {
         transform: translateY(0);
     }
 }
+
+.loading-spinner {
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 9999px;
+    border: 3px solid rgba(15, 145, 189, 0.25);
+    border-top-color: #0f91bd;
+    animation: spin 1s linear infinite;
+}
+
+#demandTableContainer.is-loading #demandTableScroll {
+    opacity: 0.4;
+    pointer-events: none;
+    transition: opacity 150ms ease;
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
+}


### PR DESCRIPTION
## Summary
- add a loading state indicator above the demand table so users see a spinner while dashboard data loads
- keep previously loaded demand rows visible during refresh while dimming the table instead of hiding it, so data always returns after the spinner
- add reusable spinner styling and tie the fetch flow to the new loading helper

## Testing
- php -l public/index.php

------
https://chatgpt.com/codex/tasks/task_e_68dfb36cf17c83279a744f9040504ee3