### PR TITLE
Handle associative API payloads on dashboard

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -1317,7 +1317,8 @@ $tabs = [
             fetch(url, { credentials: 'same-origin' })
                 .then((response) => response.json())
                 .then((payload) => {
-                    const rows = payload.data || [];
+                    const rowsSource = payload.data || [];
+                    const rows = Array.isArray(rowsSource) ? rowsSource : Object.values(rowsSource);
                     currentRows = rows.slice();
                     currentRowsMap = new Map();
                     currentRows.forEach((row) => {
@@ -1492,13 +1493,14 @@ $tabs = [
         }
 
         function renderDemandTable(rows) {
+            const normalizedRows = Array.isArray(rows) ? rows : Object.values(rows || {});
             const tableBody = document.querySelector('#demandTable tbody');
             if (!tableBody) {
                 return;
             }
             tableBody.innerHTML = '';
             let highlightedRow = null;
-            rows.forEach((row) => {
+            normalizedRows.forEach((row) => {
                 const key = `${row.warehouse_id}|${row.sku}`;
                 const tr = document.createElement('tr');
                 tr.dataset.key = key;


### PR DESCRIPTION
## Summary
- Normalize dashboard API payload handling so associative `data` objects are converted to arrays before rendering
- Update the demand table renderer to accept either array or object sources for robustness when sorting

## Testing
- php -l public/index.php

------
https://chatgpt.com/codex/tasks/task_e_68dfbbeb32d4832780ef9ebae790c64c