### PR TITLE
Handle invalid warehouse filters

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -117,7 +117,7 @@ function getSkuParameters(mysqli $mysqli): array
 function getLatestStock(mysqli $mysqli, ?int $warehouseId = null, ?string $sku = null): array
 {
     $conditions = [];
-    if ($warehouseId !== null) {
+    if ($warehouseId !== null && $warehouseId > 0) {
         $conditions[] = 'warehouse_id = ' . (int) $warehouseId;
     }
     if ($sku !== null && $sku !== '') {
@@ -163,7 +163,7 @@ function getSalesMap(mysqli $mysqli, int $lookbackDays, ?int $warehouseId = null
     $sql = 'SELECT warehouse_id, sku, sale_date, SUM(quantity) AS quantity '
         . 'FROM sales WHERE sale_date >= ?';
 
-    if ($warehouseId !== null) {
+    if ($warehouseId !== null && $warehouseId > 0) {
         $sql .= ' AND warehouse_id = ?';
         $params[] = $warehouseId;
         $types .= 'i';
@@ -431,7 +431,13 @@ function resolveParameters(
 
 function calculateDashboardData(mysqli $mysqli, array $config, array $filters = []): array
 {
-    $warehouseId = isset($filters['warehouse_id']) ? (int) $filters['warehouse_id'] : null;
+    $warehouseId = null;
+    if (isset($filters['warehouse_id'])) {
+        $candidate = (int) $filters['warehouse_id'];
+        if ($candidate > 0) {
+            $warehouseId = $candidate;
+        }
+    }
     $sku = $filters['sku'] ?? null;
 
     $warehouses = getWarehouses($mysqli);

--- a/public/api.php
+++ b/public/api.php
@@ -12,7 +12,10 @@ header('Content-Type: application/json');
 
 $filters = [];
 if (isset($_GET['warehouse_id']) && $_GET['warehouse_id'] !== '') {
-    $filters['warehouse_id'] = (int) $_GET['warehouse_id'];
+    $warehouseFilter = (int) $_GET['warehouse_id'];
+    if ($warehouseFilter > 0) {
+        $filters['warehouse_id'] = $warehouseFilter;
+    }
 }
 if (isset($_GET['sku']) && $_GET['sku'] !== '') {
     $filters['sku'] = trim((string) $_GET['sku']);


### PR DESCRIPTION
## Summary
- ignore non-positive warehouse filter values when building API requests
- treat non-positive warehouse filters as null in dashboard calculations
- guard stock and sales lookups against invalid warehouse ids so valid data still appears

## Testing
- php -l includes/functions.php
- php -l public/api.php

------
https://chatgpt.com/codex/tasks/task_e_68dfbe4f6f008327b243db3869dd8ebc