### PR TITLE
Add SQL logging for warehouse query

### DIFF
--- a/log/.gitignore
+++ b/log/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## Summary
- log the warehouses SELECT statement so the executed SQL can be inspected later
- ensure a shared log directory exists for storing sql.log entries

## Testing
- php -l includes/functions.php

------
https://chatgpt.com/codex/tasks/task_e_68dfc2a524888327b382346b47983c8e