### PR TITLE
Log dashboard warehouse selection queries

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -171,6 +171,8 @@ function getLatestStock(mysqli $mysqli, ?int $warehouseId = null, ?string $sku =
         . $where
         . ' ORDER BY warehouse_id, sku, snapshot_date DESC, id DESC';
 
+    logSqlQuery($sql, 'getLatestStock');
+
     $stock = [];
     if ($result = $mysqli->query($sql)) {
         while ($row = $result->fetch_assoc()) {
@@ -212,6 +214,15 @@ function getSalesMap(mysqli $mysqli, int $lookbackDays, ?int $warehouseId = null
     }
 
     $sql .= ' GROUP BY warehouse_id, sku, sale_date';
+
+    $logSql = $sql;
+    if ($params !== []) {
+        $encodedParams = json_encode($params);
+        if (is_string($encodedParams)) {
+            $logSql .= ' /* params: ' . $encodedParams . ' */';
+        }
+    }
+    logSqlQuery($logSql, 'getSalesMap');
 
     $stmt = $mysqli->prepare($sql);
     if (!$stmt) {


### PR DESCRIPTION
## Summary
- add SQL logging for latest stock lookups when filtering the dashboard by warehouse
- append executed sales aggregation statements and parameters to the SQL log for troubleshooting warehouse selections

## Testing
- php -l includes/functions.php

------
https://chatgpt.com/codex/tasks/task_e_68e2b1b6a7788327b38dc97751e3dcdc