### PR TITLE
Fix dashboard refresh request tracking

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -1342,6 +1342,7 @@ $tabs = [
             const controller = typeof AbortController !== 'undefined' ? new AbortController() : null;
             dashboardRequestController = controller;
             const signal = controller ? controller.signal : null;
+            const requestId = ++dashboardRequestId;
 
             setDashboardLoading(true);
 


### PR DESCRIPTION
## Summary
- increment the dashboard request counter before each fetch so responses are validated against the latest request
- avoid processing stale API payloads that arrive after a newer refresh call

## Testing
- php tests/CalculateDashboardDataTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e2db2f52b88327a863ba48e3f89aa0