### PR TITLE
Handle non-JSON dashboard responses

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -1342,6 +1342,7 @@ $tabs = [
             const controller = typeof AbortController !== 'undefined' ? new AbortController() : null;
             dashboardRequestController = controller;
             const signal = controller ? controller.signal : null;
+            const requestId = ++dashboardRequestId;
 
             setDashboardLoading(true);
 
@@ -1358,12 +1359,21 @@ $tabs = [
                         error.status = response.status;
                         throw error;
                     }
-                    return response
-                        .json()
-                        .catch((jsonError) => {
+
+                    const contentType = response.headers.get('content-type') || '';
+                    if (contentType.includes('application/json')) {
+                        return response.json().catch((jsonError) => {
                             jsonError.name = 'JsonParseError';
                             throw jsonError;
                         });
+                    }
+
+                    return response.text().then((bodyText) => {
+                        const error = new Error('Server returned a non-JSON response');
+                        error.name = 'NonJsonResponseError';
+                        error.bodyText = bodyText;
+                        throw error;
+                    });
                 })
                 .then((payload) => {
                     if (payload === null || requestId !== dashboardRequestId) {
@@ -1552,11 +1562,16 @@ $tabs = [
                         errorMessage = `Unable to load demand data (status ${error.status}). Please try again.`;
                     } else if (error.name === 'JsonParseError') {
                         errorMessage = 'Unable to load demand data because the server response was invalid. Please try again.';
+                    } else if (error.name === 'NonJsonResponseError') {
+                        errorMessage = 'Unable to load demand data because the server response was not JSON. Please contact an administrator.';
                     } else if (error.name === 'TypeError') {
                         errorMessage = 'Unable to load demand data because the request failed. Please check your connection and try again.';
                     }
                     showDemandError(errorMessage);
                     console.error('Failed to load dashboard data', error);
+                    if (error.name === 'NonJsonResponseError' && typeof error.bodyText === 'string') {
+                        console.error('Dashboard response body preview:', error.bodyText.slice(0, 300));
+                    }
                 })
                 .finally(() => {
                     if (!controller) {


### PR DESCRIPTION
## Summary
- increment the dashboard request counter before each fetch so responses are validated against the latest request
- avoid processing stale API payloads that arrive after a newer refresh call
- treat non-JSON dashboard responses as actionable errors to avoid confusing JSON parse failures

## Testing
- php tests/CalculateDashboardDataTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e2db2f52b88327a863ba48e3f89aa0